### PR TITLE
adding hasura migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,30 @@ Important files related to hasura are the `config.yaml` file at the root of the 
 - https://recipe-palette-stg.herokuapp.com/
 - https://recipe-palette.herokuapp.com/
 
-Running
+These endpoints all correspond to an app on Heroku that is running an identical instance of the Hasura `graphql-engine`.
+
+By keeping individual apps we can update the schema, or play with data in the database while updating GraphQL queries without breaking production.
+
+In order to make changes to the database don't use the link at https://recipe-palette.herokuapp.com/console, this will lead to inconsistent versions of the schema. We can turn this off with an `HASURA_GRAPHQL_ENABLE_CONSOLE=false` environment variable. It's on so we can still use GraphiQL and easily view the schema. We can change it if need be.
+
+To make changes to the schema run:
 
 ```
+hasura console --admin-secret <admin-secret>
+```
 
+When it's running it will open up a Hasura console like the one on the Heroku app with a GUI. When you make changes there however, it will automatically create timestamped migration files in the `migrations` folder. These migrations tell the Postgres database how tables are altered with up and down files. Up for editing the database to the new format, down for rolling it back. It basically saves our database schema as snapshots in time like git does for code so we can rollback to any point we may need.
+
+To apply the migrations to a deployed app run:
+
+```
+hasura migrate apply --endpoint http://another-graphql-instance.herokuapp.com
+```
+
+To check the status of migrations:
+
+```
+hasura migrate status
 ```
 
 ## 💫 Deploy

--- a/README.md
+++ b/README.md
@@ -29,47 +29,17 @@
 
     _Note: You'll also see a second link: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-five/#introducing-graphiql)._
 
-    Open the `recipepalette` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
-
 ## 🧐 What's inside?
 
-A quick look at the top-level files and directories you'll see in a Gatsby project.
+Some of the files and directories in the project.
 
     .
-    ├── node_modules
-    ├── src
-    ├── .gitignore
-    ├── .prettierrc
-    ├── gatsby-browser.js
-    ├── gatsby-config.js
-    ├── gatsby-node.js
-    ├── gatsby-ssr.js
-    ├── LICENSE
-    ├── package-lock.json
-    ├── package.json
-    └── README.md
-
-1.  **`/node_modules`**: This directory contains all of the modules of code that your project depends on (npm packages) are automatically installed.
-
-2.  **`/src`**: This directory will contain all of the code related to what you will see on the front-end of your site (what you see in the browser) such as your site header or a page template. `src` is a convention for “source code”.
-
-3.  **`.gitignore`**: This file tells git which files it should not track / not maintain a version history for.
-
-4.  **`.prettierrc`**: This is a configuration file for [Prettier](https://prettier.io/). Prettier is a tool to help keep the formatting of your code consistent.
-
-5.  **`gatsby-browser.js`**: This file is where Gatsby expects to find any usage of the [Gatsby browser APIs](https://www.gatsbyjs.org/docs/browser-apis/) (if any). These allow customization/extension of default Gatsby settings affecting the browser.
-
-6.  **`gatsby-config.js`**: This is the main configuration file for a Gatsby site. This is where you can specify information about your site (metadata) like the site title and description, which Gatsby plugins you’d like to include, etc. (Check out the [config docs](https://www.gatsbyjs.org/docs/gatsby-config/) for more detail).
-
-7.  **`gatsby-node.js`**: This file is where Gatsby expects to find any usage of the [Gatsby Node APIs](https://www.gatsbyjs.org/docs/node-apis/) (if any). These allow customization/extension of default Gatsby settings affecting pieces of the site build process.
-
-8.  **`gatsby-ssr.js`**: This file is where Gatsby expects to find any usage of the [Gatsby server-side rendering APIs](https://www.gatsbyjs.org/docs/ssr-apis/) (if any). These allow customization of default Gatsby settings affecting server-side rendering.
-
-9.  **`package-lock.json`** (See `package.json` below, first). This is an automatically generated file based on the exact versions of your npm dependencies that were installed for your project. **(You won’t change this file directly).**
-
-10. **`package.json`**: A manifest file for Node.js projects, which includes things like metadata (the project’s name, author, etc). This manifest is how npm knows which packages to install for your project.
-
-11. **`README.md`**: A text file containing useful reference information about your project.
+    ├── node_modules (installed dependencies from npm or yarn)
+    ├── src (all the code for the site, including React components)
+    ├── .gitignore (files not to check in to source control)
+    ├── .prettierrc (config for autoformatting tool Prettier)
+    ├── gatsby-config.js (plugins and Gatsby related configuration)
+    └── package.json (list of dependencies and other metadata)
 
 ## 🌲 Developing on a new branch
 
@@ -120,6 +90,20 @@ git merge <name-of-branch>
 
 You may need to fix merge conflicts if new updates to files were affected by your changes.
 
+## 👹 Hasura Migrations
+
+Important files related to hasura are the `config.yaml` file at the root of the site and the `migrations` folder. The `config.yaml` lists an endpoint to interact with when you run commands from the console. There are 3 Hasura apps deployed:
+
+- https://recipe-palette-dev.herokuapp.com/
+- https://recipe-palette-stg.herokuapp.com/
+- https://recipe-palette.herokuapp.com/
+
+Running
+
+```
+
+```
+
 ## 💫 Deploy
 
-Once the site is connected to Netlify, it can auto deploy all pushes to branches.
+Gatsby Cloud automatically creates deploy previews of all PRs, which can then be autodeployed to Netlify for hosting when merged into master.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,1 @@
+endpoint: https://recipe-palette.herokuapp.com/

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,1 +1,0 @@
-// export { wrapRootElement } from "./src/apollo/wrap-root-element"

--- a/migrations/1580422168987_update_permission_public_public_table_recipe/down.yaml
+++ b/migrations/1580422168987_update_permission_public_public_table_recipe/down.yaml
@@ -1,0 +1,24 @@
+- args:
+    role: public
+    table:
+      name: recipe
+      schema: public
+  type: drop_select_permission
+- args:
+    permission:
+      allow_aggregations: false
+      columns:
+        - id
+        - image_url
+        - latest_version
+        - parent_id
+        - private
+        - user_id
+        - variation_count
+      computed_fields: []
+      filter: {}
+    role: public
+    table:
+      name: recipe
+      schema: public
+  type: create_select_permission

--- a/migrations/1580422168987_update_permission_public_public_table_recipe/up.yaml
+++ b/migrations/1580422168987_update_permission_public_public_table_recipe/up.yaml
@@ -1,0 +1,23 @@
+- args:
+    role: public
+    table:
+      name: recipe
+      schema: public
+  type: drop_select_permission
+- args:
+    permission:
+      allow_aggregations: false
+      columns:
+        - id
+        - image_url
+        - latest_version
+        - parent_id
+        - private
+        - user_id
+      computed_fields: []
+      filter: {}
+    role: public
+    table:
+      name: recipe
+      schema: public
+  type: create_select_permission

--- a/migrations/1580422185800_alter_table_public_recipe_drop_column_variation_count/down.yaml
+++ b/migrations/1580422185800_alter_table_public_recipe_drop_column_variation_count/down.yaml
@@ -1,0 +1,11 @@
+- args:
+    sql: ALTER TABLE "public"."recipe" ADD COLUMN "variation_count" int4
+  type: run_sql
+- args:
+    sql: ALTER TABLE "public"."recipe" ALTER COLUMN "variation_count" DROP NOT NULL
+  type: run_sql
+- args:
+    sql:
+      ALTER TABLE "public"."recipe" ALTER COLUMN "variation_count" SET DEFAULT
+      0
+  type: run_sql

--- a/migrations/1580422185800_alter_table_public_recipe_drop_column_variation_count/up.yaml
+++ b/migrations/1580422185800_alter_table_public_recipe_drop_column_variation_count/up.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: ALTER TABLE "public"."recipe" DROP COLUMN "variation_count" CASCADE
+  type: run_sql

--- a/plugins/gatsby-plugin-apollo/client.js
+++ b/plugins/gatsby-plugin-apollo/client.js
@@ -7,7 +7,9 @@ export const client = new ApolloClient({
     const isBrowser = typeof window !== 'undefined'
     const token = isBrowser ? localStorage.getItem('token') : null
     operation.setContext({
-      uri: 'https://recipe-palette.herokuapp.com/v1/graphql',
+      uri:
+        process.env.GATSBY_HASURA_URL ||
+        'https://recipe-palette-dev.herokuapp.com/v1/graphql',
       headers: {
         'content-type': 'application/json',
         'x-hasura-admin-secret': 'Something 2 think about!',

--- a/src/components/cards.js
+++ b/src/components/cards.js
@@ -42,7 +42,6 @@ const RecipeCard = ({
   recipe: {
     id,
     image_url,
-    variation_count,
     latest: { name, cook_time_minutes, prep_time_minutes },
     bookmarks,
   },
@@ -117,7 +116,7 @@ const RecipeCard = ({
                 ml: `2`,
               }}
             >
-              {variation_count}
+              #
             </span>
           </div>
           <div sx={{ display: `flex`, alignItems: `center`, ml: `3` }}>

--- a/src/graphql/fragments.js
+++ b/src/graphql/fragments.js
@@ -22,7 +22,6 @@ const recipeInformationFragment = gql`
     id
     image_url
     private
-    variation_count
     latest_version
     latest {
       ...VersionInformation
@@ -54,7 +53,6 @@ const upvoteInformationFragment = gql`
 const recipeCardInformationFragment = gql`
   fragment RecipeCardInformation on recipe {
     id
-    variation_count
     image_url
     latest {
       name

--- a/src/pages/my-recipes.js
+++ b/src/pages/my-recipes.js
@@ -18,7 +18,6 @@ const recipeQuery = gql`
     ) {
       id
       image_url
-      variation_count
       latest_version
       latest {
         cook_time_minutes

--- a/src/templates/recipe.js
+++ b/src/templates/recipe.js
@@ -25,7 +25,6 @@ const recipeQuery = gql`
     variants: recipe(where: { parent_id: { _eq: $id } }) {
       id
       image_url
-      variation_count
       latest {
         name
         cook_time_minutes


### PR DESCRIPTION
This removes `variation_count` as a test for migrations. I wrote up additions to the README about how migrations work and set up 3 apps on Heroku to make deployments _hopefully_ smooth.

By running a local version of the hasura console it automatically generates the migrations that we can apply when we merge the frontend code into master (ie when this branch is merged). This would probably have to happen every time there is a change that would update the schema.